### PR TITLE
framework: Calculate MVP inside the shader

### DIFF
--- a/include/framework/graphicsProgram.hpp
+++ b/include/framework/graphicsProgram.hpp
@@ -40,11 +40,18 @@ class GraphicsProgram {
         GLuint getProgramID() {return m_ProgramID;};
 
         /**
-         * @brief Get the location of the MVP uniform
+         * @brief Get the location of the view-projection (VP) uniform
          *
-         * @return GLuint Location ID for the MVP uniform
+         * @return GLuint Location ID for the VP uniform
          */
-        GLuint getMVPLoc() {return glGetUniformLocation(m_ProgramID, "MVP");};
+        GLuint getViewProjLoc() {return glGetUniformLocation(m_ProgramID, "View_Proj");};
+
+        /**
+         * @brief Get the location of the model uniform
+         *
+         * @return GLuint Location ID for the model uniform
+         */
+        GLuint getModelLoc() {return glGetUniformLocation(m_ProgramID, "Model");};
 
 };
 

--- a/include/game/camera.hpp
+++ b/include/game/camera.hpp
@@ -58,15 +58,13 @@ class Camera {
         void setSpeed(float speed) {Speed = speed;};
 
         /**
-         * @brief Return the MVP matrix
+         * @brief Return the VP matrix
          *
-         * @details Calculates the MVP matrix associated with the camera. The model matrix must be
-         *          given as output, and the MVP matrix can be fed directly to the shader uniform.
+         * @details Calculates the view-projection (VP) matrix associated with the camera.
          *
-         * @param model_matrix The current model matrix
-         * @return glm::mat4 The MVP matrix
+         * @return glm::mat4 The VP matrix
          */
-        glm::mat4 transform(glm::mat4 model_matrix);
+        glm::mat4 calculateViewProjMatrix();
 
         /**
          * @brief Move the camera

--- a/lib/framework/graphicsFramework.cpp
+++ b/lib/framework/graphicsFramework.cpp
@@ -79,9 +79,12 @@ void GraphicsFramework::update(clock_t delta_time_ms)
 
 void GraphicsFramework::render()
 {
+    glm::mat4 vp = p_Camera->calculateViewProjMatrix();
+    glUniformMatrix4fv(m_Program->getViewProjLoc(), 1, GL_FALSE, &vp[0][0]);
+
     for (auto objPtr : v_objects) {
-        glm::mat4 mvp = p_Camera->transform(objPtr->CalculateModelMatrix());
-        glUniformMatrix4fv(m_Program->getMVPLoc(), 1, GL_FALSE, &mvp[0][0]);
+        glm::mat4 model = objPtr->CalculateModelMatrix();
+        glUniformMatrix4fv(m_Program->getModelLoc(), 1, GL_FALSE, &model[0][0]);
 
         objPtr->Render();
     }

--- a/lib/game/camera.cpp
+++ b/lib/game/camera.cpp
@@ -8,7 +8,7 @@ Camera::Camera()
     Speed = 0.1;
 }
 
-glm::mat4 Camera::transform(glm::mat4 model_matrix)
+glm::mat4 Camera::calculateViewProjMatrix()
 {
     glm::mat4 View = glm::lookAt(
         glm::vec3(Position.x, Position.y, 5), // Position of camera
@@ -20,5 +20,5 @@ glm::mat4 Camera::transform(glm::mat4 model_matrix)
                                       Dimensions.bottom, Dimensions.top,
                                       0.0f, 100.0f);
 
-    return Projection * View * model_matrix;
+    return Projection * View;
 }

--- a/src/shader/SimpleVertexShader.vertexshader
+++ b/src/shader/SimpleVertexShader.vertexshader
@@ -5,9 +5,10 @@ layout(location = 1) in vec3 vertexColor;
 
 out vec3 fragmentColor;
 
-uniform mat4 MVP;
+uniform mat4 View_Proj;
+uniform mat4 Model;
 
 void main() {
-    gl_Position = MVP * vec4(vertexPosition_modelspace,1);
+    gl_Position = View_Proj * Model * vec4(vertexPosition_modelspace,1);
     fragmentColor = vertexColor;
 }


### PR DESCRIPTION
Calculate the model and the view-projection matrices seperately in the application, and multiply them together in the vertex shader.