### PR TITLE
ci: Add GitHub Actions workflows for Docker-based builds

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,44 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ghcr.io/${{ github.repository }}/build-env
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Run nightly at 2 AM UTC
+    - cron: '0 2 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/build-env:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          submodules: recursive
+
+      - name: Copy GLEW to ext directory
+        run: |
+          mkdir -p ext
+          cp -r /deps/glew ext/
+
+      - name: Copy GLFW to ext directory
+        run: |
+          mkdir -p ext
+          cp -r /deps/glfw-3.4 ext/glfw
+
+      - name: Configure CMake
+        run: cmake -B build -DBUILD_FERD=ON -G Ninja
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Upload build artifacts
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ferd-windows-build
+          path: build/src/*.exe
+          if-no-files-found: warn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,43 @@
-FROM ubuntu:24.04 AS base
+FROM ubuntu:24.04
 
+# Install build dependencies
 RUN apt-get -y update && \
     apt-get -y upgrade && \
-    apt-get --no-install-recommends install -y adduser ca-certificates cmake curl git mingw-w64 ninja-build unzip && \
+    apt-get --no-install-recommends install -y \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        mingw-w64 \
+        ninja-build \
+        unzip && \
     apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     addgroup --system nonroot && \
     adduser --system --group nonroot
 
-WORKDIR /workdir
-
-ADD https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip glfw/glfw.zip
-RUN mkdir downloads && \
-    unzip glfw/glfw.zip -d downloads/ && \
-    chown -R nonroot:nonroot . && \
-    chown -R nonroot:nonroot downloads
-
-USER nonroot
-
+# Set up MinGW environment for Windows cross-compilation
 ENV CXX=/usr/bin/x86_64-w64-mingw32-g++
 ENV CC=/usr/bin/x86_64-w64-mingw32-gcc
 
-RUN git clone https://github.com/andvib/ferd && \
-    cd ferd && \
-    git submodule init && \
-    git submodule update && \
-    cd .. && \
-    curl -L -o glew.zip https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0-win32.zip &&\
-    unzip glew.zip -d ferd/ext/ &&\
-    mv ferd/ext/glew-2.1.0 ferd/ext/glew && \
-    mv downloads/glfw-3.4 ferd/ext/glfw
+# Download and set up GLFW
+WORKDIR /deps
+RUN chown nonroot:nonroot /deps
+
+USER nonroot
+ADD https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip /deps/glfw.zip
+RUN unzip glfw.zip && \
+    rm glfw.zip
+
+# Download and set up GLEW
+RUN curl -L -o glew.zip https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0-win32.zip && \
+    unzip glew.zip && \
+    mv glew-2.1.0 glew && \
+    rm glew.zip
+
+# Set working directory for builds
+WORKDIR /workspace
+USER root
+RUN chown nonroot:nonroot /workspace
+USER nonroot
  


### PR DESCRIPTION
Updated Dockerfile to create a reusable build environment without cloning the repo. Dependencies (GLEW, GLFW) are pre-installed in /deps and ready to be copied into projects.

Added two workflows:
- build-docker-image.yml: Builds and pushes the Docker image to GHCR when Dockerfile changes
- build.yml: Uses the pre-built image to build the project on every push/PR

This approach keeps CI runs fast by using cached Docker images and only rebuilding when dependencies change.